### PR TITLE
Add AnveVoice AI voice agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - [Visualization Tools](#visualization-tools)
 - [Software](#software)
   - [APIs](#apis)
+  - [AI & Virtual Assistants](#ai--virtual-assistants)
   - [Lead Page Builders](#lead-page-builders)
   - [Website Providers](#website-providers)
 - [License](#license)
@@ -128,6 +129,10 @@
 - [PropTech Books](https://www.proptechbuzz.com/blog/proptech-books) - A compilation of essential books for understanding PropTech.
 
 ## Software
+
+### AI & Virtual Assistants
+
+- [AnveVoice](https://anvevoice.app) - AI voice agent for real estate websites that qualifies leads, schedules property showings, answers listing questions, and talks to visitors in 50+ languages.
 
 ### APIs
 


### PR DESCRIPTION
## Summary
- Adds [AnveVoice](https://anvevoice.app) under a new **AI & Virtual Assistants** subsection in **Software**
- AnveVoice is an AI voice agent built for real estate websites — it qualifies leads, schedules property showings, answers listing questions, and speaks 50+ languages
- Updated the table of contents to include the new subsection

## Changes
- Added `AI & Virtual Assistants` to the TOC under Software
- Added AnveVoice entry matching the existing list item format