### PR TITLE
Add Property Comps -- free comparable sales data across 11 markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - [CompStak](https://www.compstak.com/) - Offers crowdsourced commercial real estate data, focusing on lease and sales comparables.
 - [Reonomy](https://www.reonomy.com/) - Provides detailed commercial real estate data and analytics, including property records and ownership information.
 - [HomesToCompare](https://homestocompare.com/) - A tool for side-by-side property comparison with AI-powered insights.
+- [Property Comps](https://nwc-advisory.com) - Free comparable property sales data across 11 global markets (UK, France, Singapore, NYC, Chicago, Dubai, Miami, Philadelphia, Connecticut, Ireland, Taiwan) using official government transaction records.
 
 ### CRMs
 


### PR DESCRIPTION
Adding Property Comps (https://nwc-advisory.com) to the Analytics Platforms section. Free comparable property sales data across 11 global markets (UK, France, Singapore, NYC, Chicago, Dubai, Miami, Philadelphia, Connecticut, Ireland, Taiwan) using official government transaction records like HM Land Registry, DVF, HDB, NYC DOF, and more. Freemium model.