### PR TITLE
Add Cost Estimation & Calculators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - [CRMs](#crms)
   - [Educational Resources](#educational-resources)
   - [Visualization Tools](#visualization-tools)
+- [Cost Estimation & Calculators](#cost-estimation--calculators)
 - [Software](#software)
   - [APIs](#apis)
   - [Lead Page Builders](#lead-page-builders)
@@ -126,6 +127,15 @@
 
 - [Emerging Trends in Real Estate®](https://www.pwc.com/us/en/industries/financial-services/asset-wealth-management/real-estate/emerging-trends-in-real-estate-pwc-uli.html) - An annual forecast report on investment and development trends.
 - [PropTech Books](https://www.proptechbuzz.com/blog/proptech-books) - A compilation of essential books for understanding PropTech.
+
+## Cost Estimation & Calculators
+
+- [Simulateur Prix Construction Maison](https://simulateur-prix-construction-maison.fr/) - Free French construction cost estimator with 36 criteria and 25 budget line items, built by a construction professional with 30+ years of experience. Covers all regions of France.
+- [Budget-Maison.com](https://budget-maison.com/) - Quick French construction budget estimator.
+- [Calculette ForumConstruire](https://www.forumconstruire.com/calculatrices/) - Collection of French construction calculators (PTZ, surface, materials).
+- [HomeAdvisor True Cost Guide](https://www.homeadvisor.com/cost/) - U.S.-focused home improvement and construction cost data.
+- [RSMeans](https://www.rsmeans.com/) - Industry-standard construction cost data and estimation tools (U.S. and Canada).
+- [Build It Calculator](https://www.self-build.co.uk/calculator/) - UK self-build cost calculator.
 
 ## Software
 


### PR DESCRIPTION
## Summary

This PR adds a new **Cost Estimation & Calculators** section to the awesome list, covering construction cost estimation tools from multiple countries:

- **France**: Simulateur Prix Construction Maison, Budget-Maison.com, Calculette ForumConstruire
- **USA/Canada**: HomeAdvisor True Cost Guide, RSMeans
- **UK**: Build It Calculator

Construction cost estimation is a key part of the real estate journey (especially for new builds), and this category was missing from the list. The section is linked in the table of contents.

No existing content was modified — this is purely additive.