### PR TITLE
Add PermisAPI to Software > APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@
 - [HouseCanary Core API](https://www.housecanary.com/pricing) - Access to the core API, CanaryAI, and AVM reports for advanced property valuation modeling.
 - [RentCast API](https://www.rentcast.io/api) - Scalable API for rental estimates, market data, and portfolio monitoring.
 - [RealEstateAPI.com](http://www.realestateapi.com/) - API designed for PropTech solutions with unlimited property data and integrated machine-learning capabilities.
+- [PermisAPI](https://permisapi.fr) - REST API for 311,000+ French building permits (Sitadel dataset, geocoded via BAN, webhooks, Python SDK).
 
 ### Lead Page Builders
 


### PR DESCRIPTION
Adds PermisAPI to the Software > APIs section.

**PermisAPI** exposes the French Sitadel dataset (311,000+ building permits across France since 2022) as a modern REST API:

- 97.2% geocoded via the French Base Adresse Nationale
- 11 query filters (department, municipality, type, dates, floor area, SIREN, etc.)
- Geospatial search (PostGIS radius queries)
- HMAC-SHA256 signed webhooks for real-time alerts
- Official Python SDK on PyPI: `pip install permisapi-client`
- Free tier: 500 requests/month, no credit card

It fills a gap in the existing list: all current APIs focus on US real estate, transactions or listings. PermisAPI covers the European / French building permits angle (pre-acquisition signals, urban planning data, zoning authorizations).

Data source: French Ministère de la Transition écologique (SDES), under the Etalab open license 2.0.

Website: https://permisapi.fr
Docs: https://api.permisapi.fr/docs