### PR TITLE
Add BC Property Check to Foundational Geospatial & Urban Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 - [Awesome Spatial Data](https://github.com/bchapuis/awesome-spatial-data) - A meta-list for foundational global spatial datasets.
 - [Awesome Urban Datasets](https://github.com/urban-toolkit/awesome-urban-datasets) - Curated public datasets for urban planning.
 - [Awesome Geospatial](https://github.com/sacridini/Awesome-Geospatial) - A broad compilation of geospatial tools and resources.
+- [BC Property Check](https://bcpropertycheck.ca/) - Free parcel intelligence for British Columbia, Canada - zoning, density (Bill 44 SSMUH), riparian setbacks, ALR, BC Hydro corridors, all from open government data.
 
 ### Authoritative Research & Publications
 


### PR DESCRIPTION
Adds [BC Property Check](https://bcpropertycheck.ca/) — a free public web tool for British Columbia, Canada — to the **Foundational Geospatial & Urban Data** subsection.

It aggregates public-data sources (provincial DataBC + LTSA ParcelMap BC + per-municipality ArcGIS) into a single per-parcel brief covering zoning, the new BC Bill 44 SSMUH unit yield, Bill 47 Transit-Oriented Area density tier, Agricultural Land Reserve, riparian setbacks, contaminated sites, floodplain, and BC Hydro transmission corridors. It also includes a pro-forma calculator.

Free, no signup. BC-only. Single-line addition, alphabetical placement (after the Awesome-* entries).