### PR TITLE
Add ArchiWise to Analytics Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - [CompStak](https://www.compstak.com/) - Offers crowdsourced commercial real estate data, focusing on lease and sales comparables.
 - [Reonomy](https://www.reonomy.com/) - Provides detailed commercial real estate data and analytics, including property records and ownership information.
 - [HomesToCompare](https://homestocompare.com/) - A tool for side-by-side property comparison with AI-powered insights.
+- [ArchiWise](https://archiwise.ai) - AI-powered real estate pre-development and site selection platform that helps developers, architects, brokers, and planning consultants analyze zoning, feasibility, and site data in under 5 minutes.
 
 ### CRMs
 


### PR DESCRIPTION
Hi, I've added ArchiWise (https://archiwise.ai) to the list, an AI-powered real estate pre-development and site selection platform that helps developers, architects, brokers, and planning consultants analyze zoning, feasibility, and site data in under 5 minutes.

Happy to make any adjustments if needed. Thanks for considering it!