### PR TITLE
Add Cost Segregation Benchmarks 2026 (open-data, CC-BY) to Authoritative Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@
 
 - [Emerging Trends in Real Estate®](https://www.pwc.com/us/en/industries/financial-services/asset-wealth-management/real-estate/emerging-trends-in-real-estate-pwc-uli.html) - An annual forecast report on investment and development trends.
 - [PropTech Books](https://www.proptechbuzz.com/blog/proptech-books) - A compilation of essential books for understanding PropTech.
+- [Cost Segregation Benchmarks 2026](https://costsegsmart.com/research/benchmarks-2026/) - Open-data report on 260 cost segregation studies across 13 US property types. Reports median reclassification percentages, year-1 federal tax savings, and US provider pricing. CC-BY 4.0 licensed; CSV dataset available.
 
 ## Software
 


### PR DESCRIPTION
## What this adds

A single new entry in the **Authoritative Research & Publications** section: [Cost Segregation Benchmarks 2026](https://costsegsmart.com/research/benchmarks-2026/) — an open-data report on n=260 cost segregation studies across 13 US property types, CC-BY 4.0 licensed.

## Why it fits this list

- The section currently has 2 entries (PwC's *Emerging Trends* and a PropTech books compilation). This adds an industry-wide cost-segregation dataset — a topic the list doesn't currently cover but is a high-information-need area for the real-estate-investor audience this list serves.
- The dataset is open (CSV download), open-licensed (CC-BY 4.0), and citable. Quotable findings: median STR property reclassifies ~29.8% of basis vs. ~18.3% for unfurnished SFR; US provider pricing ranges $495 to $15,000 for the same IRS-compliant methodology.
- Methodology page is published alongside, with full disclosure of data sources, sample composition, and limitations.

## Disclosure

I operate Cost Seg Smart, the publisher of the report. Adding here because (a) it's the only open-licensed industry-wide cost-seg dataset I'm aware of, (b) it fits the existing "research & publications" theme cleanly, and (c) cost segregation is an underrepresented topic in the list relative to its importance in real-estate investor tax strategy. Happy to adjust wording or position if you'd prefer.

The entry follows the existing format and matches the conciseness of the surrounding bullets.