### PR TITLE
Add Zip-Codes API to Software → APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@
 - [HouseCanary Core API](https://www.housecanary.com/pricing) - Access to the core API, CanaryAI, and AVM reports for advanced property valuation modeling.
 - [RentCast API](https://www.rentcast.io/api) - Scalable API for rental estimates, market data, and portfolio monitoring.
 - [RealEstateAPI.com](http://www.realestateapi.com/) - API designed for PropTech solutions with unlimited property data and integrated machine-learning capabilities.
-
+- [Zip-Codes API](https://www.zip-codes.com/api/) - U.S. ZIP and Canadian postal code data with demographics, Census   boundaries, school districts, radius search, and address validation.
+  
 ### Lead Page Builders
 
 - [SinglePropertyPages](https://singlepropertypages.com) - Affordable and easy-to-use lead page builder.


### PR DESCRIPTION
  Adds Zip-Codes API to the Software → APIs section.

  REST API for US ZIP, ZIP+4, and Canadian postal codes. Use cases relevant to real estate:

  - Market analysis by ZIP — demographics from Census ACS 2011–2024 (income, household composition, education, housing,
  etc.)
  - Territory mapping — radius search (centroid and spatial polygon) for service areas and lead routing
  - Community profiling — Census tract, congressional district, state legislative, and school district lookup per ZIP,
  with overlap percentages
  - Address validation and ZIP+4 append for listing data quality
  - Canadian postal code coverage (FSA + full postal codes) — most peers in this section are US-only

  Resources:
  - Docs: https://api.zip-codes.com/docs
  - OpenAPI: https://api.zip-codes.com/v2/openapi.json
  - Free tier: 2,500 lookups/day