### PR TITLE
Add BailleurVerif (open dataset of non-compliant French rental listings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - [Real-Estate-Financial-Analytics-Dashboard](https://github.com/YSayaovong/Real-Estate-Financial-Analytics-Dashboard) - A Power BI and PostgreSQL dashboard for long-term rental property financial analysis.
 - [Investment Portfolio Optimization](https://github.com/MarionJelimo/real-estate-investment-portfolio-optimization-using-time-series) - A project for time series forecasting of property values.
 - [Real Estate Price Prediction Project](https://github.com/shanuhalli/Project-Real-Estate-Price-Prediction) - An end-to-end data science project for real estate price prediction.
+- [BailleurVerif](https://github.com/Creariax5/bailleurverif) - Open dataset of non-compliant French rental listings (7 cities, ~210 listings/wave, 11 git-timestamped temporal waves, 57.6% cross-wave persistence, daily crawl). MIT-licensed Python pipeline + Etalab v2.0 dataset on data.gouv.fr for housing market research and regulatory compliance analytics.
 
 ## Resources
 


### PR DESCRIPTION
## What is BailleurVerif

BailleurVerif is an open research project that publishes a continuously refreshed dataset of non-compliant rental listings in 7 French cities (Paris, Lyon, Marseille, Bordeaux, Toulouse, Nantes, Lille). Listings are scraped daily, checked against French rent-control and DPE (energy performance) regulation, and the results are published under Etalab v2.0 (open) on data.gouv.fr.

What makes the dataset distinctive for real-estate researchers / proptech tooling:

- **11 git-timestamped temporal waves** (since 2026-03), each wave is an immutable commit on GitHub — non-rejouable provenance.
- **Cross-wave persistence analysis**: 121/210 listings (57.6%) persist across 3 consecutive waves — useful signal for stale-listing vs fresh-listing classification.
- **Methodology fully public**: MIT-licensed Python pipeline (scrapers + DPE/encadrement compliance rules + DILA legal corpus) — reproducible.
- **Etalab v2.0 dataset**: free for commercial + research use, dofollow on data.gouv.fr (DR ~90).

## Why it fits "GitHub Projects" section

The existing section already lists scrapers (HomeHarvest, Real Estate Data Scraper) and analytics projects (price prediction, ROI calculators). BailleurVerif is in the same spirit but adds two angles missing from the current list:

1. **A published reusable dataset**, not just a tool (Etalab v2.0 / data.gouv.fr).
2. **French market coverage** with regulatory-compliance lens (rent-control thresholds, mandatory DPE disclosure) — useful for international researchers studying European housing regulation.

## Resources

- Repo (MIT): https://github.com/Creariax5/bailleurverif
- Dataset on data.gouv.fr: https://www.data.gouv.fr/fr/datasets/annonces-de-location-francaises-non-conformes-observatoire-bailleurverif/
- Reuse / methodology page: https://www.data.gouv.fr/fr/reuses/bailleurverif-observatoire-annonces-loyer-non-conformes-encadrement-dpe-f-g/
- Cross-wave persistence (JSON): https://bailleurverif.fr/data/cross-wave-persistence.json

Happy to revise framing, category, or wording if it doesn't fit the curation criteria — thanks for maintaining the list.