### PR TITLE
Add Prestyj Lead Response & AI Sales Statistics dataset under Authoritative Research & Publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@
 
 - [Emerging Trends in Real Estate®](https://www.pwc.com/us/en/industries/financial-services/asset-wealth-management/real-estate/emerging-trends-in-real-estate-pwc-uli.html) - An annual forecast report on investment and development trends.
 - [PropTech Books](https://www.proptechbuzz.com/blog/proptech-books) - A compilation of essential books for understanding PropTech.
+- [Prestyj Lead Response & AI Sales Statistics](https://prestyj.com/data) - Open dataset (CC BY 4.0) of 58 cite-worthy statistics on speed-to-lead, real estate ISA response benchmarks, AI adoption in sales, and CPL by industry. Downloadable as CSV/JSON; each row carries its primary publisher (HBR, InsideSales, HubSpot, McKinsey, etc.) and year.
 
 ## Software
 


### PR DESCRIPTION
Adds one entry under `### Authoritative Research & Publications` pointing to an open CC BY 4.0 dataset of 58 cite-worthy statistics relevant to real estate teams — including speed-to-lead benchmarks, ISA response data, AI sales adoption, and cost-per-lead by industry.

- Landing page (with schema.org/Dataset markup): https://prestyj.com/data
- Direct CSV: https://prestyj.com/data/statistics.csv
- Direct JSON: https://prestyj.com/data/statistics.json
- Mirror repo: https://github.com/Gahroot/prestyj-statistics-dataset
- License: CC BY 4.0

Each row carries its primary publisher (Harvard Business Review, InsideSales, HubSpot, WordStream, McKinsey, Gartner, Salesforce, etc.) and publication year, so it's quotable in real estate research/content without re-verification.

Useful for brokerage analysts, real estate marketers, and PropTech researchers studying lead response performance and AI adoption in residential sales.