### PR TITLE
Add GeoInfomatic (Korean neighborhood accessibility analyzer, no listings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@
 
 ## Resources
 
+
+- [GeoInfomatic — Living Zone Accessibility (Korea)](https://geoinfomatic.pythonanywhere.com) - Isochrone-based neighborhood accessibility analyzer for South Korea. Pick any address, see 10/20/30/45-min walking or transit reachability with 8 facility types overlaid. 100-point composite score with AI summary. No real-estate listings — pure accessibility analysis for moving / due-diligence decisions. Freemium.
 ### Blogs
 
 - [GeekEstateBlog](http://geekestateblog.com/) - Insightful articles with a focus on technology.


### PR DESCRIPTION
Adds **GeoInfomatic** — a real-estate decision-support tool specifically built without property listings.

- URL: https://geoinfomatic.pythonanywhere.com
- Use case: moving / relocation / urban-planning / school-district comparison
- Output: 100-point composite accessibility score + AI natural-language summary
- Transit mode breaks results down by transfer count (0/1/2+) which most tools skip

Solo-built. Freemium model (5 free analyses/day, $7/month Pro for unlimited + PDF reports). Open to feedback / different placement.
