### PR TITLE
Add SafeStreets to Analytics Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - [CompStak](https://www.compstak.com/) - Offers crowdsourced commercial real estate data, focusing on lease and sales comparables.
 - [Reonomy](https://www.reonomy.com/) - Provides detailed commercial real estate data and analytics, including property records and ownership information.
 - [HomesToCompare](https://homestocompare.com/) - A tool for side-by-side property comparison with AI-powered insights.
+- [SafeStreets](https://safestreets.streetsandcommons.com) - Free address-level walkability and pedestrian-safety analysis with neighborhood scores and crash-based pedestrian risk, useful for relocation and property research.
 
 ### CRMs
 


### PR DESCRIPTION
Adds [SafeStreets](https://safestreets.streetsandcommons.com) to **Resources → Analytics Platforms**.

SafeStreets gives free, address-level walkability and pedestrian-safety scores (15-minute-city framework) plus crash-based pedestrian risk, built on OpenStreetMap and public data — useful for relocation and property research. Fits alongside HouseCanary and HomesToCompare.