### PR TITLE
Add Superhighway web search API to Software > APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@
 - [HouseCanary Core API](https://www.housecanary.com/pricing) - Access to the core API, CanaryAI, and AVM reports for advanced property valuation modeling.
 - [RentCast API](https://www.rentcast.io/api) - Scalable API for rental estimates, market data, and portfolio monitoring.
 - [RealEstateAPI.com](http://www.realestateapi.com/) - API designed for PropTech solutions with unlimited property data and integrated machine-learning capabilities.
+- [Superhighway](https://superhighway.walls.sh) - Web search, news, scrape, and research API for AI agents. Useful for building real estate research agents that pull listings, scrape property pages, and gather neighborhood context. See the [real estate research agent guide](https://superhighway.walls.sh/guides/real-estate-agent).
 
 ### Lead Page Builders
 


### PR DESCRIPTION
## What

Adds [Superhighway](https://superhighway.walls.sh) to the **Software > APIs** section.

Superhighway is a web search, news, scrape, and research API built for AI agents. It's a good fit alongside the other property-data APIs here because it's commonly used to build real estate research agents — pulling listings, scraping property pages, and gathering neighborhood/market context.

The entry also links to a [real estate research agent guide](https://superhighway.walls.sh/guides/real-estate-agent) that walks through building a Python agent which searches listings, scrapes property details, researches neighborhoods, and scores properties with an LLM.

## Why it fits

- Lives in the existing APIs section with a one-line description matching the list's format
- Relevant to developers building modern real estate / PropTech applications, the stated audience of this list

Thanks for maintaining this list!