### PR TITLE
Add Ritn3D to Visualization Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 - [Cubicasa](https://www.cubicasa.com/) - A fast and accurate floor plan generation tool for real estate listings.
 - [iGUIDE](https://goiguide.com/) - Provides interactive 3D tours and floor plans for real estate listings.
 - [AI Virtual Staging](https://www.aivirtualstaging.net/) - AI powered Virtual Staging that preserves the original room layout and dimensions
+- [Ritn3D](https://www.ritn3d.com/) - AI floor plan to 3D model converter. Upload a PDF, JPG, or PNG floor plan and get a walkable 3D interior model in under 2 minutes. Free tier, native iOS and Android apps, web app, and share-via-browser-link with no install for the recipient.
 
 ### Foundational Geospatial & Urban Data
 


### PR DESCRIPTION
Ritn3D fits the Visualization Tools section — it converts 2D floor plans into interactive 3D models that real estate agents can share with buyers via a browser link (no install or account needed for the recipient).

- Auto-detects walls, doors, windows, and rooms from PDF / JPG / PNG floor plans
- Generates a walkable 3D interior in under 2 minutes
- Free tier (3 renders/month) available, paid plans from $9.99/mo
- Native apps on iOS and Android, plus a web app at app.ritn3d.com

Useful for agents preparing 3D content for sub-$500K residential listings as a cheaper alternative to on-site capture tools.