### PR TITLE
Add UrbanKit Studio Parcel API to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@
 - [HouseCanary Core API](https://www.housecanary.com/pricing) - Access to the core API, CanaryAI, and AVM reports for advanced property valuation modeling.
 - [RentCast API](https://www.rentcast.io/api) - Scalable API for rental estimates, market data, and portfolio monitoring.
 - [RealEstateAPI.com](http://www.realestateapi.com/) - API designed for PropTech solutions with unlimited property data and integrated machine-learning capabilities.
+- [UrbanKit Studio Parcel API](https://urbankitstudio.com/developers) - Address→owner/APN/mailing enrichment plus a verified ArcGIS REST endpoint directory for 155 US counties (free tier, $19/mo developer API, MCP server + npm SDK).
 
 ### Lead Page Builders
 


### PR DESCRIPTION
Adds UrbanKit Studio to **Software → APIs**.

UrbanKit Studio provides address→owner/APN/mailing-address enrichment plus a verified ArcGIS REST endpoint directory for 155 US counties (all 50 states) — the affordable/free-tier complement to the existing ATTOM / RentCast / HouseCanary entries, built on public county endpoints:
- Free tier + a $19/mo developer API
- Machine-readable CSV/JSON endpoint directory (CC BY 4.0)
- MCP server (`@urbankitstudio/mcp-atlas`) + npm SDK (`@urbankitstudio/atlas`)

Thanks for maintaining awesome-real-estate!