### PR TITLE
Add WohnRadar Schweiz to Analytics Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - [CompStak](https://www.compstak.com/) - Offers crowdsourced commercial real estate data, focusing on lease and sales comparables.
 - [Reonomy](https://www.reonomy.com/) - Provides detailed commercial real estate data and analytics, including property records and ownership information.
 - [HomesToCompare](https://homestocompare.com/) - A tool for side-by-side property comparison with AI-powered insights.
+- [WohnRadar Schweiz](https://wohnradarschweiz.ch/) - Monitors official Swiss building-permit notices (Baugesuche) by address and alerts owners/neighbors by email before the public objection deadline expires.
 
 ### CRMs
 


### PR DESCRIPTION
Adds WohnRadar Schweiz (wohnradarschweiz.ch), a Swiss building-permit monitoring tool, in the same section/style as the existing entries (HouseCanary, CompStak, Reonomy, HomesToCompare).