### PR TITLE
Add US Real Estate Exam Data dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 - [Lone Wolf](https://www.lwolf.com/) - A comprehensive real estate platform with CRM, transaction management, and accounting tools.
 
 ### Educational Resources
+- [US Real Estate Exam Data](https://github.com/roykim26/us-real-estate-exam-data) - Comprehensive dataset of US real estate licensing exam requirements, fees, and pass rates across all 50 states
 
 - [BiggerPockets](https://www.biggerpockets.com/) - A leading platform for real estate investors, providing education, podcasts, and networking.
 - [Masterclass: Real Estate](https://www.masterclass.com/) - Professional real estate courses from industry experts.


### PR DESCRIPTION
## Add US Real Estate Exam Data

### New Resource
Adding a comprehensive open-source dataset for US real estate exam preparation:

- **US Real Estate Exam Data**: Covers all 50 states with exam requirements, fees, education hours, and pass rates
- **Data formats**: CSV and JSON
- **License**: CC BY 4.0

### Why this resource
This dataset is valuable for:
- Real estate exam preparation platforms
- Market research and analysis
- Comparison tools for prospective agents
- Educational content creation

### Checklist
- [x] Resource is free and open-source
- [x] Description is clear and accurate
- [x] No duplicate entries
- [x] Follows the existing format