### PR TITLE
Add Estate property API to Software > APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@
 
 ### APIs
 
+- [Estate](https://estate.sh/developers) - Read-only API for current Georgia property listings, locations, prices, and exchange rates.
 - [Zillapi](https://zillapi.com) - Real-time Zillow property data API: Zestimates, rent estimates, tax records, price history, and listing search. Also an MCP server for AI agents. OAuth 2.1, free tier.
 - [Rets Rabbit](http://www.retsrabbit.com) - Import real estate listings and photos from RETS or ListHub.
 - [Zoo Property](http://www.zooproperty.com/api/) - RESTful API to manage property listings.


### PR DESCRIPTION
## What are you adding?

Estate, a free read-only Georgia property listings and market-data API, under Software > APIs.

## Checklist

- [x] The link is live and loads correctly
- [x] It's in the correct section, and isn't already listed elsewhere in the README
- [x] The description is one line, ends with a period, and doesn't just repeat the item's name
- [x] I am affiliated with this listing and have disclosed that below

## Affiliation

I am the founder of Estate.

## Validation

- The documentation page and public options endpoint returned HTTP 200.
- The API requires no authentication, uses HTTPS, and advertises permissive CORS.
- The table of contents remained unchanged and git diff whitespace validation passed.
