### PR TITLE
Add Phuket condo asking-price research

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@
 - [PropTech Books](https://www.proptechbuzz.com/blog/proptech-books) - A compilation of essential books for understanding PropTech.
 - [Prestyj Lead Response & AI Sales Statistics](https://prestyj.com/data) - Open dataset (CC BY 4.0) of 58 cite-worthy statistics on speed-to-lead, real estate ISA response benchmarks, AI adoption in sales, and CPL by industry. Downloadable as CSV/JSON; each row carries its primary publisher (HBR, InsideSales, HubSpot, McKinsey, etc.) and year.
 - [Cost Segregation Benchmarks 2026](https://costsegsmart.com/research/benchmarks-2026/) - Open-data report on 260 cost segregation studies across 13 US property types. Reports median reclassification percentages, year-1 federal tax savings, and US provider pricing. CC-BY 4.0 licensed; CSV dataset available.
-- [Phuket Condo Asking-Price Snapshot](https://kvartiry-phuket.com/ceny/) - CC BY 4.0 aggregate research covering 391 exact-URL-deduplicated Phuket condo sale-listing observations from April to July 2026, with methodology, limitations, charts, and downloadable CSV/JSON; asking prices, not transactions or active inventory.
+- [Phuket Condo Asking-Price Snapshot](https://kvartiry-phuket.com/en/phuket-condo-prices/) - CC BY 4.0 aggregate research covering 391 exact-URL-deduplicated Phuket condo sale-listing observations from April to July 2026, with methodology, limitations, charts, and downloadable CSV/JSON; asking prices, not transactions or active inventory.
 
 ## Cost Estimation & Calculators
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@
 - [PropTech Books](https://www.proptechbuzz.com/blog/proptech-books) - A compilation of essential books for understanding PropTech.
 - [Prestyj Lead Response & AI Sales Statistics](https://prestyj.com/data) - Open dataset (CC BY 4.0) of 58 cite-worthy statistics on speed-to-lead, real estate ISA response benchmarks, AI adoption in sales, and CPL by industry. Downloadable as CSV/JSON; each row carries its primary publisher (HBR, InsideSales, HubSpot, McKinsey, etc.) and year.
 - [Cost Segregation Benchmarks 2026](https://costsegsmart.com/research/benchmarks-2026/) - Open-data report on 260 cost segregation studies across 13 US property types. Reports median reclassification percentages, year-1 federal tax savings, and US provider pricing. CC-BY 4.0 licensed; CSV dataset available.
+- [Phuket Condo Asking-Price Snapshot](https://kvartiry-phuket.com/ceny/) - CC BY 4.0 aggregate research covering 391 exact-URL-deduplicated Phuket condo sale-listing observations from April to July 2026, with methodology, limitations, charts, and downloadable CSV/JSON; asking prices, not transactions or active inventory.
 
 ## Cost Estimation & Calculators
 


### PR DESCRIPTION
## What are you adding?

The Phuket Condo Asking-Price Snapshot under **Authoritative Research & Publications**.

It is a public English-language CC BY 4.0 aggregate research page covering 391 exact-URL-deduplicated Phuket condo sale-listing observations collected from 19 April through 20 July 2026. The page provides the methodology, sample limitations, charts, and downloadable aggregate CSV/JSON. The proposed description explicitly distinguishes asking prices from transactions and active inventory.

## Checklist

- [x] The English research link is live and loads correctly (HTTP 200, no sign-up or paywall).
- [x] It is in the correct section and is not already listed.
- [x] The description is one line, ends with a period, and adds useful detail.
- [x] Affiliation is disclosed below.
- [x] The table of contents remains unchanged and the repository TOC check reports it is current.

## Affiliation

I am submitting this on behalf of Kvartiry Phuket, the publisher of the research resource. This is our own resource; the affiliation is disclosed so it can be reviewed on its merits.