### PR TITLE
Add PropAIdir to Educational Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 
 - [BiggerPockets](https://www.biggerpockets.com/) - A leading platform for real estate investors, providing education, podcasts, and networking.
 - [Masterclass: Real Estate](https://www.masterclass.com/) - Professional real estate courses from industry experts.
+- [PropAIdir](https://www.propaidir.com) - An independent directory of AI tools for real estate agents, brokers, and property investors, with no sponsored rankings or pay-to-play.
 - [Udemy Real Estate Courses](https://www.udemy.com/topic/real-estate/) - Offers a variety of courses covering real estate investing, property management, and market analysis.
 
 ### Gamification


### PR DESCRIPTION
Adds PropAIdir to the Educational Resources section. It is an independent directory of AI tools for real estate agents, brokers, and property investors, with no sponsored rankings or pay-to-play.

Affiliation disclosure: This is a project-affiliated submission made on behalf of PropAIdir.

Checks completed:
- [x] The canonical link is live.
- [x] PropAIdir and propaidir.com are not already listed.
- [x] The entry is one descriptive line in the existing Educational Resources section.
- [x] The entry ends with a period and does not repeat the resource name as its description.
- [x] The README passes awesome-lint and its table of contents remains unchanged.