### PR TITLE
Add Bangkok Off-Plan Housing Pipeline to Authoritative Research & Publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@
 - [Prestyj Lead Response & AI Sales Statistics](https://prestyj.com/data) - Open dataset (CC BY 4.0) of 58 cite-worthy statistics on speed-to-lead, real estate ISA response benchmarks, AI adoption in sales, and CPL by industry. Downloadable as CSV/JSON; each row carries its primary publisher (HBR, InsideSales, HubSpot, McKinsey, etc.) and year.
 - [Cost Segregation Benchmarks 2026](https://costsegsmart.com/research/benchmarks-2026/) - Open-data report on 260 cost segregation studies across 13 US property types. Reports median reclassification percentages, year-1 federal tax savings, and US provider pricing. CC-BY 4.0 licensed; CSV dataset available.
 - [Phuket Condo Asking-Price Snapshot](https://kvartiry-phuket.com/en/phuket-condo-prices/) - CC BY 4.0 aggregate research covering 391 exact-URL-deduplicated Phuket condo sale-listing observations from April to July 2026, with methodology, limitations, charts, and downloadable CSV/JSON; asking prices, not transactions or active inventory.
+- [Bangkok Off-Plan Housing Pipeline](https://baanscope.com/data) - CC BY 4.0 aggregates of the residential construction underway in the Bangkok Metropolitan Region, compiled from the public listings of Thailand's nine largest listed developers and re-checked every two days; 81 districts, 9 developers and 6 completion years as CSV/JSON with a column dictionary, reporting project and unit counts, median asking prices and government-appraised land values rather than transactions.
 
 ## Cost Estimation & Calculators
 


### PR DESCRIPTION
Adds one entry to **Authoritative Research & Publications**, alongside the Phuket asking-price snapshot — same shape of resource: CC BY 4.0 aggregate data with a published methodology and explicit limits.

**What it is.** Aggregates of the residential construction underway in the Bangkok Metropolitan Region, compiled from the public project listings of Thailand's nine largest listed developers and re-checked roughly every two days. 81 districts, 9 developers and 6 completion years, with project and unit counts, property mix, median asking prices, median price per m² and median government-appraised land values.

**Checks from contributing.md:**

- Link is live — CSV and JSON download directly from the page, no signup, no paywall.
- Not already listed — searched the README for `baanscope` and for the dataset name.
- Right section — it is research/data rather than a tool or a platform, matching the CC BY 4.0 dataset entries already there.
- `awesome-lint` run locally: no content errors. (It reports two repo-level "awesome"/"awesome-list" GitHub-topic warnings that predate this change and aren't contributor-fixable.)
- TOC untouched — no new section, so no `doctoc` run needed.

**Disclosure:** I maintain the dataset.

Worth flagging in the entry itself, and stated there: these are developer asking prices, not transactions. Thailand has no public transaction registry, so nothing in this space can honestly claim sale prices.