### PR TITLE
Add Restar to Analytics Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 
 - [AssessorSearch](https://assessorsearch.com/) - Search U.S. property records by address, APN, parcel number, or owner name, with assessor data, tax records, deeds, permits, and county-source links.
 - [HouseCanary](https://www.housecanary.com/) - Provides real estate data and analytics, including home valuation models and market forecasting.
+- [Restar](https://restar.io/) - Housing market scores and 12-month price forecasts for every US state, metro, county and ZIP code, built from Zillow, Redfin, Census, BLS, FHFA and Federal Reserve data. Market pages are free with no account.
 - [CompStak](https://compstak.com/) - Offers crowdsourced commercial real estate data, focusing on lease and sales comparables.
 - [Reonomy](https://www.reonomy.com/) - Provides detailed commercial real estate data and analytics, including property records and ownership information.
 - [HomesToCompare](https://homestocompare.com/) - A tool for side-by-side property comparison with AI-powered insights.


### PR DESCRIPTION
Adds [Restar](https://restar.io/) under **Analytics Platforms**.

Restar publishes housing-market data for every US geography — all 50 states, 993 metro areas, 3,221 counties and 33,791 ZIP codes — aggregating Zillow, Redfin, Census ACS/PEP/BPS, BLS, FHFA, HUD and Federal Reserve series into a 0–100 market score and a 12-month price forecast.

It sits naturally next to HouseCanary in that section (valuation models and market forecasting), with the difference that market pages are free and need no account, and every metric links to a public page documenting how it is calculated and which source it came from.

One entry, one line, no other changes.