### PR TITLE
Add AssetCalcs to Cost Estimation & Calculators

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@
 - [HomeAdvisor True Cost Guide](https://www.homeadvisor.com/cost/) - U.S.-focused home improvement and construction cost data.
 - [RSMeans](https://www.rsmeans.com/) - Industry-standard construction cost data and estimation tools (U.S. and Canada).
 - [Build It Calculator](https://www.self-build.co.uk/build-cost-calculator/) - UK self-build cost calculator.
+- [AssetCalcs](https://assetcalcs.com/) - Fast, ad-free investment and tax calculators for US/UK real estate investors (DSCR, BRRRR, Cap Rate, Hard Money, and BTL).
 
 ## Software
 


### PR DESCRIPTION
## What are you adding?

Adding **AssetCalcs** to the `Cost Estimation & Calculators` section. 

Markdown line added:
`- [AssetCalcs](https://assetcalcs.com/) - Fast, ad-free investment and tax calculators for US/UK real estate investors (DSCR, BRRRR, Cap Rate, Hard Money, and BTL).`

## Checklist

- [x] The link is live and loads correctly (not a parked domain, a 404, or a paywall-only page)
- [x] It's in the correct section, and isn't already listed elsewhere in the README
- [x] The description is one line, ends with a period, and doesn't just repeat the item's name
- [x] I'm not affiliated with this listing — **or** I am, and I've said so below

## Affiliation (if any)

I am the founder/creator of AssetCalcs. Built it as a clean, ad-free, fast alternative to heavy/cluttered financial tools.
