### PR TITLE
Add SAA Homes — Northern Colorado real estate resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@
 ### Educational Resources
 
 - [BiggerPockets](https://www.biggerpockets.com/) - A leading platform for real estate investors, providing education, podcasts, and networking.
+
+- [SAA Homes — Northern Colorado Real Estate](https://saahomes.com/) - Free buyer and seller guides, CHFA down payment assistance breakdowns, area guides for 19+ Front Range communities, and monthly MLS-sourced market reports for Fort Collins, Loveland, Windsor, and Greeley.
 - [Masterclass: Real Estate](https://www.masterclass.com/) - Professional real estate courses from industry experts.
 - [Udemy Real Estate Courses](https://www.udemy.com/topic/real-estate-fundamentals/) - Offers a variety of courses covering real estate investing, property management, and market analysis.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@
 ### Educational Resources
 
 - [BiggerPockets](https://www.biggerpockets.com/) - A leading platform for real estate investors, providing education, podcasts, and networking.
-
 - [SAA Homes — Northern Colorado Real Estate](https://saahomes.com/) - Free buyer and seller guides, CHFA down payment assistance breakdowns, area guides for 19+ Front Range communities, and monthly MLS-sourced market reports for Fort Collins, Loveland, Windsor, and Greeley.
 - [Masterclass: Real Estate](https://www.masterclass.com/) - Professional real estate courses from industry experts.
 - [Udemy Real Estate Courses](https://www.udemy.com/topic/real-estate-fundamentals/) - Offers a variety of courses covering real estate investing, property management, and market analysis.


### PR DESCRIPTION
## Resource to Add

**Name:** SAA Homes — Northern Colorado Real Estate (Schwartz and Associates)
**URL:** https://saahomes.com/
**Category:** Educational Resources

Schwartz and Associates (SAA Homes) is a Coldwell Banker Realty team serving Fort Collins, Loveland, Windsor, Greeley, and 19+ Northern Colorado Front Range communities. The site provides free educational resources for home buyers and sellers including:

- **[CHFA Down Payment Assistance Guide](https://saahomes.com/chfa-down-payment-assistance/)** — Complete breakdown of Colorado first-time homebuyer programs (SmartStep, FirstStep, Schools to Home) with income limits and purchase price caps by county
- **[Northern Colorado Area Guides](https://saahomes.com/northern-colorado-areas/)** — Detailed neighborhood profiles, school district maps, and market data for 19 communities
- **[Monthly Market Reports](https://saahomes.com/blog/)** — IRES MLS-sourced market snapshots with median prices, days on market, and inventory levels

Fits under **Educational Resources** as a practical, data-backed resource for buyers and sellers in the Colorado market.