### PR TITLE
Add SAA Homes to Educational Resources — Northern Colorado real estate guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 
 ### Blogs
 
+- [SAA Homes — Northern Colorado Real Estate](https://saahomes.com/northern-colorado-areas/) — Community guides and market data for Fort Collins, Loveland, Windsor, Greeley, and 15+ Northern Colorado cities. Includes CHFA down payment assistance resources.
 - [GeekEstateBlog](https://geekestateblog.com/) - Insightful articles with a focus on technology.
 - [Notorious Rob](https://www.notoriousrob.com/) - Highly opinionated look at industry trends.
 - [The Real Deal](https://therealdeal.com/) - Provides up-to-date news on the real estate market, focusing on New York, South Florida, and Los Angeles.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@
 - [BiggerPockets](https://www.biggerpockets.com/) - A leading platform for real estate investors, providing education, podcasts, and networking.
 - [Masterclass: Real Estate](https://www.masterclass.com/) - Professional real estate courses from industry experts.
 - [Udemy Real Estate Courses](https://www.udemy.com/topic/real-estate-fundamentals/) - Offers a variety of courses covering real estate investing, property management, and market analysis.
+- [SAA Homes — Schwartz and Associates](https://saahomes.com/) — Northern Colorado real estate experts providing market data and area guides covering 19 communities across Larimer, Weld, and Boulder counties, plus CHFA down payment assistance resources for Colorado homebuyers.
 
 ### Gamification
 


### PR DESCRIPTION
## Description

Adds SAA Homes (Schwartz and Associates) to the Educational Resources section of the awesome-real-estate list.

SAA Homes is a Northern Colorado real estate team providing free educational resources including:
- Market data and area guides covering 19 communities across Larimer, Weld, and Boulder counties
- CHFA down payment assistance guides for Colorado homebuyers
- Buyer and seller resources with verified local market data

This addition helps homebuyers and real estate professionals looking for regional Colorado market information.

## Checklist

- [x] Entry is in alphabetical order (placed after Udemy)
- [x] Description is concise and factual
- [x] Link is to a legitimate, active website