### PR TITLE
Add AddressIntel to Compliance & Permit Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@
 
 ### Compliance & Permit Tools
 
+- [AddressIntel](https://addressintel.co/permits) - Free building-permit tracker with address-level search for SF Peninsula and South Bay cities, updated daily from municipal sources.
 - [Van Permit Audit](https://www.vanpermitaudit.ca/) - AI compliance checker for Vancouver, Canada building permits — validates permit PDFs against City of Vancouver bylaws and returns a structured pass/fail report.
 
 ### Lead Page Builders


### PR DESCRIPTION
Adds AddressIntel under Compliance & Permit Tools.

It is a free building-permit tracker for SF Peninsula and South Bay cities, with address-level search at addressintel.co/permits/search. Permits are pulled daily from municipal sources and the city open-data portals, so the alternative for most of this area is checking each city's permit portal one at a time.

Disclosure: I built it. The link works with no signup and no paywall.

Checked against contributing.md before opening:

- Link is live (200) and needs no signup.
- Not already listed (no existing match for the name or domain in README.md).
- One line, ending with a period, in the section it belongs to.
- Adds a list item under an existing heading, so the doctoc ToC is unchanged.
