### PR TITLE
Add Lender Questionnaire to Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 ### Directories
 
 - [Gipety](https://gipety.com) - A sourced, dated directory of UK real-estate software providers, covering website builders, CRMs, listing portals, valuation tools, and media platforms.
+- [Lender Questionnaire](https://lenderquestionnaire.com) - Free directory of 14,181 registered community associations in Hawaii, Nevada, Texas, and Virginia, naming the management company of record who answers a lender questionnaire or estoppel request for each one. Built from each state's own public register, with the source and the date it was read on every page, and downloadable as CSV. No signup.
 
 ### Analytics Platforms
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@
 ### Directories
 
 - [Gipety](https://gipety.com) - A sourced, dated directory of UK real-estate software providers, covering website builders, CRMs, listing portals, valuation tools, and media platforms.
-- [Lender Questionnaire](https://lenderquestionnaire.com) - Free directory of 14,181 registered community associations in Hawaii, Nevada, Texas, and Virginia, naming the management company of record who answers a lender questionnaire or estoppel request for each one. Built from each state's own public register, with the source and the date it was read on every page, and downloadable as CSV. No signup.
+- [Lender Questionnaire](https://lenderquestionnaire.com) - Free directory of 14,181 registered community associations in Hawaii, Nevada, Texas, and Virginia, naming the management company of record who answers a lender questionnaire or estoppel request, for the 9,824 whose register gives one. Built from each state's own public register, with the source and the date it was read on every page, and downloadable as CSV. No signup.
 
 ### Analytics Platforms
 


### PR DESCRIPTION
Adds a free, sourced directory to the Directories section.

It covers 14,181 registered community associations in Hawaii, Nevada, Texas and Virginia, and names the management company of record who answers a lender questionnaire or estoppel request for the 9,824 of them whose state register gives one. That is the lookup a loan officer, a title agent or a buyer's agent otherwise makes by phone.

- Built from each state's own public register, not scraped from listings.
- Every page prints its source and the date the register was read.
- The whole set downloads as CSV, no signup and no paywall.

Same shape as the existing Gipety entry: a sourced, dated directory rather than a product.

Edited to correct the count: an earlier draft said the management company was named for each of the 14,181, and it is named for 9,824.