### PR TITLE
Add marocain.investments to AI & Virtual Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@
 ### AI & Virtual Assistants
 
 - [AnveVoice](https://anvevoice.app) - AI voice agent for real estate websites that qualifies leads, schedules property showings, answers listing questions, and talks to visitors in 50+ languages.
+- [marocain.investments](https://marocain.investments) - Independent AI verdict engine for Moroccan real estate covering buy, rent, and owner-side valuation, with a public MCP server so AI agents can query the graded catalogue directly.
 
 ### Inspection & Reporting
 


### PR DESCRIPTION
Adds **marocain.investments** to _Software > AI & Virtual Assistants_.

**What it is:** independent AI verdict engine for Moroccan real estate — {GIN} score (buy/watch/pass), automated valuation model, rent-vs-market read, and honest legal risk assessment. Serves buyers, renters, and property owners in EN/FR/ES/DE/PL/AR. Live production with 20,700+ live sale listings and 15,700+ live rentals from 17 integrated sources. Ships a public MCP server (`@marocain/mcp-server` on npm + the Official MCP Registry) so AI agents can query the graded catalogue directly.

**Section fit:** _AI & Virtual Assistants_ — closest match to an AI verdict/valuation engine that ships an agent-facing MCP interface (existing AnveVoice entry is voice-agent-focused; marocain is data/verdict-focused for the Morocco vertical, which the list currently has no entry for).

**Contributing checklist:**
- Link is live (production, hosted on Vercel).
- Not already listed — searched for `marocain`, `morocco`, `maghreb` before submitting.
- One line, ends with a period, doesn't just repeat the name.
- Put in the right section (AI). If a country / Morocco / MENA subsection is preferred, happy to move.
- **Affiliation disclosed:** I work on marocain.investments (CTO). Submitting per your welcome of affiliated contributors in `contributing.md`.

Repo: https://github.com/Hei33enberg/Marocain_Investments · npm: https://www.npmjs.com/package/@marocain/mcp-server