### PR TITLE
Add Canadian Rental Address Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [Awesome Urban Datasets](https://github.com/urban-toolkit/awesome-urban-datasets) - Curated public datasets for urban planning.
 - [Awesome Geospatial](https://github.com/sacridini/Awesome-Geospatial) - A broad compilation of geospatial tools and resources.
 - [BC Property Check](https://bcpropertycheck.ca/) - Free parcel intelligence for British Columbia, Canada - zoning, density (Bill 44 SSMUH), riparian setbacks, ALR, BC Hydro corridors, all from open government data.
+- [Canadian Rental Address Research](https://github.com/Fink692/canadian-rental-data-sources) - Open, source-dated directory of official Canadian property, permit, tenancy, hazard, transit, and neighbourhood resources for pre-lease address research.
 
 ### Authoritative Research & Publications
 


### PR DESCRIPTION
Adds one live, no-signup resource under **Foundational Geospatial & Urban Data**.

Canadian Rental Address Research is a free, MIT-licensed, source-dated directory of official property, permit, tenancy, hazard, transit, and neighbourhood resources for renters researching an address before a lease. It currently covers eight Canadian cities and includes a machine-readable CSV plus explicit limitations.

Affiliation disclosure: I maintain the submitted repository and also build BlockScore. The repository clearly discloses that relationship and contains one optional early-access link; this list entry links only to the open GitHub resource.

Validation:
- link resolves publicly without signup or a paywall
- no duplicate name or domain found
- one line in the relevant section, ending with a period
- `git diff --check` passes