### PR TITLE
Add HomeGPT and RoomsGPT to Visualization Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@
 - [Ritn3D](https://www.ritn3d.com/) - AI floor plan to 3D model converter. Upload a PDF, JPG, or PNG floor plan and get a walkable 3D interior model in under 2 minutes. Free tier, native iOS and Android apps, web app, and share-via-browser-link with no install for the recipient.
 - [EquitySight](https://equitysight.app/) - Free Australian property investment platform with tools to help buyers and investors make smarter decisions.
 - [voxelyo](https://voxelyo.com) - AI photo enhancement subscription for Airbnb, Vrbo, and real estate listing photos, with denoising, sharpening, upscaling, and color correction on a flat unlimited plan.
+- [HomeGPT](https://www.homegpt.app/) - AI exterior, yard, and garden redesign from a house photo, with material cost calculators.
+- [RoomsGPT](https://www.roomsgpt.io/) - AI interior redesign from a room photo, with 61+ styles.
 
 ### Foundational Geospatial & Urban Data
 


### PR DESCRIPTION
## What are you adding?

HomeGPT and RoomsGPT under Resources → Visualization Tools, next to Pedra, AI Virtual Staging, and Ritn3D.

- [HomeGPT](https://www.homegpt.app/) — AI exterior, yard, and garden redesign from a house photo, with material cost calculators.
- [RoomsGPT](https://www.roomsgpt.io/) — AI interior redesign from a room photo, with 61+ styles.

Both links are live (200).

## Checklist

- [x] The link is live and loads correctly (not a parked domain, a 404, or a paywall-only page)
- [x] It's in the correct section, and isn't already listed elsewhere in the README
- [x] The description is one line, ends with a period, and doesn't just repeat the item's name
- [x] I'm not affiliated with this listing — **or** I am, and I've said so below

## Affiliation (if any)

I'm the founder of both HomeGPT and RoomsGPT.