### PR TITLE
Add Underlytix to North America / Analytics Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@
 - [Restar](https://restar.io/) - Housing market scores and 12-month price forecasts for every US state, metro, county and ZIP code, built from Zillow, Redfin, Census, BLS, FHFA and Federal Reserve data. Market pages are free with no account.
 - [Reonomy](https://www.reonomy.com/) - Provides detailed commercial real estate data and analytics, including property records and ownership information.
 - [Amortio](https://www.amortio.com/) - Free mortgage calculators using Freddie Mac PMMS rate data, with PITI breakdown, FHA/VA/USDA loan eligibility, and refinance break-even analysis.
+- [Underlytix](https://underlytix.com) - Deal-fundability scoring for real estate investors, realtors, and lenders. Returns a Capital Readiness Score with DSCR, LTV, and cash-on-cash analysis plus matched lender recommendations, before a loan application or credit pull.
 
 ### Educational Resources
 


### PR DESCRIPTION
Adding **Underlytix** (https://underlytix.com) under North America → Analytics Platforms.

Underlytix scores a real estate deal's fundability before the borrower approaches a lender — a Capital Readiness Score built from DSCR, LTV, and cash-on-cash analysis, with lender recommendations matched to the deal type. Used by investors, realtors, and lenders.

- US-only (DSCR loan products, US lender network), so placed under North America
- One entry, same `- [Name](url) - Description.` format as the rest of the section
- Adjacent in scope to the existing Altyst entry (Global), which does DSCR/IRR underwriting for commercial real estate
