### PR TITLE
Update Bangkok Off-Plan Housing Pipeline entry: eight tables, four of them public-register joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@
 ### Authoritative Research & Publications
 
 - [Phuket Condo Asking-Price Snapshot](https://kvartiry-phuket.com/en/phuket-condo-prices/) - CC BY 4.0 aggregate research covering 391 exact-URL-deduplicated Phuket condo sale-listing observations from April to July 2026, with methodology, limitations, charts, and downloadable CSV/JSON; asking prices, not transactions or active inventory.
-- [Bangkok Off-Plan Housing Pipeline](https://baanscope.com/data) - CC BY 4.0 aggregates of the residential construction underway in the Bangkok Metropolitan Region, compiled from the public listings of Thailand's nine largest listed developers and re-checked every two days; 81 districts, 9 developers and 6 completion years as CSV/JSON with a column dictionary, reporting project and unit counts, median asking prices and government-appraised land values rather than transactions.
+- [Bangkok Off-Plan Housing Pipeline](https://baanscope.com/data) - CC BY 4.0 aggregates of the residential construction underway in the Bangkok Metropolitan Region, compiled from the public listings of Thailand's nine largest listed developers and re-checked every two days; eight tables as CSV/JSON with a column dictionary. Four cover the pipeline by district, developer, completion year and rail line, reporting project and unit counts, median asking prices and government-appraised land values rather than transactions. Four join it to public registers: the city plan (floor area ratio in force per land-use class, and what the March 2026 draft would change), the national EIA register (filings approved and still recorded as not started), the city's monitored flood points, and OpenStreetMap amenities within 800 m.
 
 ## Oceania
 


### PR DESCRIPTION
Updates the one-line entry merged in #53. It described three cuts and a district count that has moved; there are now eight tables, and four of them are a different kind of thing.

The original four cover the pipeline: by district, by developer, by completion year and by rail line. The four new ones join that pipeline to public registers that are not otherwise readable against what is being sold:

- **City plan**: floor area ratio and open space ratio in force per land-use class, and what the March 2026 draft plan would change.
- **EIA register**: environmental filings approved by the national regulator and still recorded as not started, by district.
- **Flood points**: distance to the road locations the city's drainage department monitors.
- **Walkable amenities**: OpenStreetMap amenities within 800 m.

Same URL, same licence (CC BY 4.0), same caveat that these are developer asking prices rather than transactions, because Thailand publishes no transaction registry.

One line changed, nothing else touched.